### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -4,12 +4,12 @@
   <name>MAF Norge Oppgave XML</name>
   <description>CiviCRM native extension to manage the yearly tax declaration process for MAF Norge </description>
   <license>AGPL-3.0</license>
-<urls>
+  <urls>
     <url desc="Main Extension Page">https://github.com/CiviCooP/no.maf.oppgavexml</url>
     <url desc="Documentation">https://github.com/CiviCooP/no.maf.oppgavexml</url>
     <url desc="Support">http://www.civicoop.org</url>
     <url desc="Licensing">http://civicrm.org/licensing</url>
-</urls>  
+  </urls>
   <maintainer>
     <author>CiviCooP</author>
     <email>helpdesk@civicoop.org</email>
@@ -18,8 +18,7 @@
   <version>1.4</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>4.3</ver>
-    <ver>4.7</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments>Extension is being tested</comments>
   <civix>

--- a/templates/CRM/Oppgavexml/Page/TaxYearList.tpl
+++ b/templates/CRM/Oppgavexml/Page/TaxYearList.tpl
@@ -7,7 +7,7 @@
     <form action="{crmURL p='civicrm/oppgave/load'}" method="GET">
       <div class="form-layout">
         <label for="year">{ts}Year{/ts}</label> <input type="text" name="year" size="4" value="{$current_year}" class="small crm-form-text" />
-        <input type="submit" value="{ts}Load{/ts}" class="crm-form-submit default" />
+        <input type="submit" value="{ts escape='htmlattribute'}Load{/ts}" class="crm-form-submit default" />
       </div>
     </form>
   </div>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.