### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Oppgavexml/Config.php
+++ b/CRM/Oppgavexml/Config.php
@@ -329,7 +329,7 @@ class CRM_Oppgavexml_Config {
     try {
       $customGroup = civicrm_api3('CustomGroup', 'getsingle', array('name' => $customGroupName,));
     }
-    catch (CiviCRM_API3_Exception $ex) {
+    catch (CRM_Core_Exception $ex) {
       throw new Exception('Could not find a custom group with name '.$customGroupName.' in '.__METHOD__
         .', contact your system administrator. Error from API CustomGroup getsingle : '.$ex->getMessage());
     }
@@ -341,7 +341,7 @@ class CRM_Oppgavexml_Config {
         'return' => 'column_name',
       ));
     }
-    catch (CiviCRM_API3_Exception $ex) {
+    catch (CRM_Core_Exception $ex) {
       throw new Exception('Could not find a custom field with name '.$customFieldName.' within custom group '
         .$customGroupName.' in '.__METHOD__.', contact your system administrator. Error from API CustomField getvalue : '
         .$ex->getMessage());

--- a/CRM/Oppgavexml/OptionGroup.php
+++ b/CRM/Oppgavexml/OptionGroup.php
@@ -24,7 +24,7 @@ class CRM_OppgaveXml_OptionGroup {
       );
       try {
         $option_group = civicrm_api3('OptionGroup', 'Create', $params);
-      } catch (CiviCRM_API3_Exception $ex) {
+      } catch (CRM_Core_Exception $ex) {
         throw new Exception('Could not create option group tax_declaration_year_status, '
           . 'error from API OptionGroup Create: '.$ex->getMessage());      
       }
@@ -61,7 +61,7 @@ class CRM_OppgaveXml_OptionGroup {
       'return' => 'id');
     try {
       $option_group_id = civicrm_api3('OptionGroup', 'Getvalue', $option_group_params);
-    } catch (CiviCRM_API3_Exception $ex) {
+    } catch (CRM_Core_Exception $ex) {
       throw new Exception('Could not find option group with name tax_declaration_year_status, '
         . 'error from API OptionGroup Getvalue: '.$ex->getMessage());
     }
@@ -71,7 +71,7 @@ class CRM_OppgaveXml_OptionGroup {
       'return' => 'value');
     try {
       $value = civicrm_api3('OptionValue', 'Getvalue', $option_value_params);
-    } catch (CiviCRM_API3_Exception $ex) {
+    } catch (CRM_Core_Exception $ex) {
       $value = '';
     }
     return $value;
@@ -89,7 +89,7 @@ class CRM_OppgaveXml_OptionGroup {
       'return' => 'id');
     try {
       $option_group_id = civicrm_api3('OptionGroup', 'Getvalue', $option_group_params);
-    } catch (CiviCRM_API3_Exception $ex) {
+    } catch (CRM_Core_Exception $ex) {
       throw new Exception('Could not find option group with name tax_declaration_year_status, '
         . 'error from API OptionGroup Getvalue: '.$ex->getMessage());
     }
@@ -99,7 +99,7 @@ class CRM_OppgaveXml_OptionGroup {
       'return' => 'label');
     try {
       $label = civicrm_api3('OptionValue', 'Getvalue', $option_value_params);
-    } catch (CiviCRM_API3_Exception $ex) {
+    } catch (CRM_Core_Exception $ex) {
       $label = '';
     }
     return $label;
@@ -126,7 +126,7 @@ class CRM_OppgaveXml_OptionGroup {
       try {
         civicrm_api3('OptionValue', 'Create', $params);
         $value++;
-      } catch (CiviCRM_API3_Exception $ex) {
+      } catch (CRM_Core_Exception $ex) {
         throw new Exception('Could not create option value '.$status_label.' in option group '
           .$option_group_id.', error from API OptionValue Create: '.$ex->getMessage());
       }

--- a/api/v3/Oppgave/Get.php
+++ b/api/v3/Oppgave/Get.php
@@ -6,7 +6,7 @@
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_oppgave_get($params) {
   $return_values = CRM_Oppgavexml_BAO_Oppgave::get_values($params);

--- a/api/v3/TaxDeclarationYear/Export.php
+++ b/api/v3/TaxDeclarationYear/Export.php
@@ -22,7 +22,7 @@ function _civicrm_api3_tax_declaration_year_export_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_tax_declaration_year_export($params) {
   validate_params($params);
@@ -42,22 +42,22 @@ function civicrm_api3_tax_declaration_year_export($params) {
  * Function to validate incoming params
  * 
  * @param array $params
- * @throws API_Exception when no param year found
- * @throws API_Exception when param year is empty
- * @throws API_Exception when param year is not 4 digits long
- * @throws API_Exception when param year is not numeric
+ * @throws CRM_Core_Exception when no param year found
+ * @throws CRM_Core_Exception when param year is empty
+ * @throws CRM_Core_Exception when param year is not 4 digits long
+ * @throws CRM_Core_Exception when param year is not numeric
  */
 function validate_params($params) {
   if (!array_key_exists('year', $params)) {
-    throw new API_Exception('Year is a mandatory param but is not found in passed params');
+    throw new CRM_Core_Exception('Year is a mandatory param but is not found in passed params');
   }
   if (empty($params['year'])) {
-    throw new API_Exception('Param year can not be empty');
+    throw new CRM_Core_Exception('Param year can not be empty');
   }
   if (strlen($params['year']) != 4) {
-    throw new API_Exception('Year has to have 4 digits');
+    throw new CRM_Core_Exception('Year has to have 4 digits');
   }
   if (!is_numeric($params['year'])) {
-    throw new API_Exception('Year has to be numeric');
+    throw new CRM_Core_Exception('Year has to be numeric');
   }
 }

--- a/api/v3/TaxDeclarationYear/Load.php
+++ b/api/v3/TaxDeclarationYear/Load.php
@@ -158,7 +158,7 @@ function oppgavexml_getDonorData($contactId) {
   try {
     $contactData = civicrm_api3('Contact', 'Getsingle', $params);
     $donorData = oppgavexml_pullDonorData($contactData);
-  } catch (CiviCRM_API3_Exception $ex) {
+  } catch (CRM_Core_Exception $ex) {
     $donorData = array();
   }
   return $donorData;
@@ -230,23 +230,23 @@ function oppgavexml_createSkatteinnberetninger($params) {
  * Function to validate incoming params
  * 
  * @param array $params
- * @throws API_Exception when no param year found
- * @throws API_Exception when param year is empty
- * @throws API_Exception when param year is not 4 digits long
- * @throws API_Exception when param year is not numeric
+ * @throws CRM_Core_Exception when no param year found
+ * @throws CRM_Core_Exception when param year is empty
+ * @throws CRM_Core_Exception when param year is not 4 digits long
+ * @throws CRM_Core_Exception when param year is not numeric
  */
 function oppgavexml_validateParams(&$params) {
   if (!array_key_exists('year', $params)) {
-    throw new API_Exception('Year is a mandatory param but is not found in passed params');
+    throw new CRM_Core_Exception('Year is a mandatory param but is not found in passed params');
   }
   if (empty($params['year'])) {
-    throw new API_Exception('Param year can not be empty');
+    throw new CRM_Core_Exception('Param year can not be empty');
   }
   if (strlen($params['year']) != 4) {
-    throw new API_Exception('Year has to have 4 digits');
+    throw new CRM_Core_Exception('Year has to have 4 digits');
   }
   if (!is_numeric($params['year'])) {
-    throw new API_Exception('Year has to be numeric');
+    throw new CRM_Core_Exception('Year has to be numeric');
   }
 }
 /**


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.